### PR TITLE
package.json: Replace `test` script with `ember test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
-      - run: pnpm test:ember
+      - run: pnpm test
 
   try-scenarios:
     name: ${{ matrix.try-scenario }}

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "lint:js:fix": "eslint . --fix",
     "release": "release-it",
     "start": "ember serve",
-    "test": "npm-run-all lint test:*",
-    "test:ember": "ember test",
-    "test:ember-compatibility": "ember try:each"
+    "test": "ember test"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",


### PR DESCRIPTION
Having `ember-try` kick in unintentionally after `pnpm test` is unnecessarily annoying...