### PR TITLE
GitHub Pages: Migrate to `locationType: history`

### DIFF
--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -3,6 +3,13 @@ import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'dummy/config/environment';
 
+// see https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/
+let redirect = sessionStorage.redirect;
+delete sessionStorage.redirect;
+if (redirect && redirect !== location.href) {
+  history.replaceState(null, null, redirect);
+}
+
 export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -49,7 +49,6 @@ module.exports = function (environment) {
 
   if (process.env.DEPLOY_TARGET === 'GitHub Pages') {
     ENV.rootURL = '/ember-error-route';
-    ENV.locationType = 'hash';
   }
 
   return ENV;

--- a/tests/dummy/public/404.html
+++ b/tests/dummy/public/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      sessionStorage.redirect = location.href;
+    </script>
+    <meta http-equiv="refresh" content="0;URL='/ember-error-route'">
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
based on https://www.smashingmagazine.com/2016/08/sghpa-single-page-app-hack-github-pages/