### PR TITLE
Remove broken `colors@1.4.2` subdependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4062,11 +4062,6 @@ packages:
     dev: true
     optional: true
 
-  /colors/1.4.2:
-    resolution: {integrity: sha512-5QhJWPFZqkKIieXJPpCprdOytvH7v0AGWpu9K2jZ4LWkGg3dVBNoYPgGGRpEsc0jb8Boy0ElYrdjH9uXfhRSqw==}
-    engines: {node: '>=0.1.90'}
-    dev: true
-
   /combined-stream/1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -5313,7 +5308,7 @@ packages:
       '@glimmer/syntax': 0.83.1
       '@glimmer/validator': 0.83.1
       async-promise-queue: 1.0.5
-      colors: 1.4.2
+      colors: 1.4.0
       commander: 8.3.0
       globby: 11.1.0
       ora: 5.4.1


### PR DESCRIPTION
This is currently breaking CI because at the time of the lockfile update this version existed, but was later deleted again, causing the requests to return "404 Not Found".